### PR TITLE
Code cleanup, small optimisations and single matrix pcc implementation

### DIFF
--- a/R/interface.R
+++ b/R/interface.R
@@ -2,12 +2,19 @@
 
 # PCC matrix c wrapper
 PCC <- function(aM, bM = NULL, use = NULL, asMatrix = TRUE, debugOn = FALSE) {
-  if(is.null(bM)) bM <- aM
+  n = as.integer(nrow(aM))
+  m = as.integer(ncol(aM))
+  if(is.null(bM)) {
+    p = 0
+    bM <- aM
+  } else {
+    p = as.integer(ncol(bM))
+  }
   res <- .C("R_pcc_matrix", aM = as.double(aM),
                             bM = as.double(bM),
-                            n = as.integer(nrow(aM)), # nInd
-                            m = as.integer(ncol(aM)), # nPhe A
-                            p = as.integer(ncol(bM)), # nPhe B
+                            n, # nInd
+                            m, # nPhe A
+                            p, # nPhe B
                             res = as.double(rep(0, ncol(aM) * ncol(bM))), NAOK = TRUE, package = "MPCC")
 
   if(asMatrix) res$res <- matrix(res$res, ncol(aM), ncol(bM), byrow=TRUE, dimnames = list(colnames(aM), colnames(bM)))

--- a/src/MPCC.cpp
+++ b/src/MPCC.cpp
@@ -414,7 +414,7 @@ int pcc_matrix(int m, int n, int p,
     GEMM(CblasRowMajor, CblasNoTrans, transB,
          m, p, n, alpha, A, n, UnitB, ldb, beta, SA, p); 
 
-    //SB = B*UnitA
+    //SB = UnitA*B
     //Compute sum of B for each AB row col pair.
     // This requires multiplication with a UnitA matrix which acts as a mask 
     // to prevent missing data in AB pairs from contributing to the sum
@@ -431,7 +431,7 @@ int pcc_matrix(int m, int n, int p,
     GEMM(CblasRowMajor, CblasNoTrans, transB,
          m, p, n, alpha, AA, n, UnitB, ldb, beta, SAA, p); 
 
-    //SBB = BB*UnitA
+    //SBB = UnitA*BB
     //Compute sum of BB for each AB row col pair.
     // This requires multiplication with a UnitA matrix which acts as a mask 
     // to prevent missing data in AB pairs from contributing to the sum
@@ -469,10 +469,10 @@ int pcc_matrix(int m, int n, int p,
 
     //SASB=SA*SB
     VMUL(m*p,SA,SB,SASB);
-    //N*SASB
+    //NSAB=N*SAB
     VMUL(m*p,N,SAB,NSAB); //ceb
 
-    //NSAB=(-1)NSASB+SAB  (numerator)
+    //NSAB=(-1)NSAB+SASB  (numerator)
     AXPY(m*p,(DataType)(-1), SASB,1, NSAB,1); //ceb
 
     //(SA)^2

--- a/src/MPCC.cpp
+++ b/src/MPCC.cpp
@@ -297,8 +297,6 @@ int pcc_matrix(int m, int n, int p,
   //allocate and initialize and align memory needed to compute PCC
   DataType *N = (DataType *) ALLOCATOR( m*p,sizeof( DataType ), 64 );
   __assume_aligned(N, 64);
-  DataType *M = (DataType *) ALLOCATOR( m*p, sizeof( DataType ), 64 );
-  __assume_aligned(M, 64);
   DataType* SA =    ( DataType*)ALLOCATOR( m*p, sizeof(DataType), 64 ); 
   __assume_aligned(SA, 64);
   DataType* AA =    ( DataType*)ALLOCATOR( m*n, sizeof(DataType), 64 ); 
@@ -325,11 +323,10 @@ int pcc_matrix(int m, int n, int p,
   //info("after calloc\n",1);
 
   //if any of the above allocations failed, then we have run out of RAM on the node and we need to abort
-  if ( (N == NULL) | (M == NULL) | (SA == NULL) | (AA == NULL) | (SAA == NULL) | (SB == NULL) | (BB == NULL) | 
+  if ( (N == NULL) | (SA == NULL) | (AA == NULL) | (SAA == NULL) | (SB == NULL) | (BB == NULL) | 
       (SBB == NULL) | (SAB == NULL) | (UnitA == NULL) | (UnitB == NULL) | (amask == NULL) | (bmask == NULL)) {
     err("ERROR: Can't allocate memory for intermediate matrices. Aborting...\n", 1);
     FREE(N);
-    FREE(M);
     FREE(SA);
     FREE(AA);
     FREE(SAA);

--- a/src/MPCC.cpp
+++ b/src/MPCC.cpp
@@ -491,6 +491,7 @@ int pcc_matrix(int m, int n, int p,
 
     //DENOM=NSAA*NSBB (element wise multiplication)
     VMUL(m*p,NSAA,NSBB,DENOM);
+    #pragma omp parallel for private (i)
     for(int i=0;i<m*p;++i){
        if(DENOM[i]==0.){DENOM[i]=1;}//numerator will be 0 so to prevent inf, set denom to 1
     }

--- a/src/MPCC.cpp
+++ b/src/MPCC.cpp
@@ -282,8 +282,11 @@ void initialize(int &m, int &n, int &p, int seed,
 //This function is the implementation of a matrix x matrix algorithm which computes a matrix of PCC values
 //but increases the arithmetic intensity of the naive pairwise vector x vector correlation
 //A is matrix of X vectors and B is transposed matrix of Y vectors:
-//P = [ sum(AB) - (sumA)(sumB)/N] /
-//    sqrt[ ( sumA^2 -(1/N) (sum A/)^2)[ ( sumB^2 - (1/N)(sum B)^2) ]
+//P = [ sum(AB) - (sumA)(sumB)/N ] /
+//    sqrt([ (sumA^2 -(1/N)(sum A)^2) ][ (sumB^2 - (1/N)(sum B)^2) ])
+//
+//P = [ N*sum(AB) - (sumA)(sumB)] /
+//    sqrt([ (N*sumA^2 - (sum A)^2) ][ (N*sumB^2 - (sum B)^2) ])
 int pcc_matrix(int m, int n, int p,
                DataType* A, DataType* B, DataType* P)
 {

--- a/src/MPCC.cpp
+++ b/src/MPCC.cpp
@@ -355,11 +355,11 @@ int pcc_matrix(int m, int n, int p,
     #pragma omp parallel for private (i,k)
     for (i=0; i<m; i++) {
       for (k=0; k<n; k++) {
-        amask[ i*n + k ] = 1.0;
         if (CHECKNA(A[i*n+k])) { 
           amask[i*n + k] = 0.0;
           A[i*n + k] = 0.0; // set A to 0.0 for subsequent calculations of PCC terms
         }else{
+          amask[ i*n + k ] = 1.0;
           UnitA[i*n + k] = 1.0;
         }
       }
@@ -369,11 +369,11 @@ int pcc_matrix(int m, int n, int p,
     #pragma omp parallel for private (j,k)
     for (j=0; j<p; j++) {
       for (k=0; k<n; k++) {
-        bmask[ j*n + k ] = 1.0;
         if (CHECKNA(B[j*n+k])) { 
           bmask[j*n + k] = 0.0;
           B[j*n + k] = 0.0; // set B to 0.0 for subsequent calculations of PCC terms
         }else{
+          bmask[ j*n + k ] = 1.0;
           UnitB[j*n + k] = 1.0;
         }
       }


### PR DESCRIPTION
Removed matrix M allocation as it wasn't being used.

Added reformulated equation above pcc function that is used by it.

Slight change in amask, bmask assignment loop if statements to reduce number of assignments.

Fixed some comments that didn't match with the corresponding operation (operands weren't correct).

Added omp statement above one loop by the end.

Rest of the commits are for adding the pcc_matrix function which calculates pcc for one matrix input and is optimised for one matrix input. Renamed previous pcc_matrix to pcc_matmat.